### PR TITLE
fix .is-valid and .is-invalid in css

### DIFF
--- a/src/components/styled/select.css
+++ b/src/components/styled/select.css
@@ -145,16 +145,16 @@
   }
 }
 
-.select:focus:valid ~ .select-floating-label,
+.select:focus.is-valid ~ .select-floating-label,
 .validate .select:focus:valid ~ .select-floating-label,
-.select:focus:valid ~ .select-filled-label,
+.select:focus.is-valid ~ .select-filled-label,
 .validate .select:focus:valid ~ .select-filled-label {
   @apply text-success;
 }
 
-.select:focus:invalid ~ .select-floating-label,
+.select:focus.is-invalid ~ .select-floating-label,
 .validate .select:focus:invalid ~ .select-floating-label,
-.select:focus:invalid ~ .select-filled-label,
+.select:focus.is-invalid ~ .select-filled-label,
 .validate .select:focus:invalid ~ .select-filled-label {
   @apply text-error;
 }

--- a/src/components/styled/select.css
+++ b/src/components/styled/select.css
@@ -145,17 +145,17 @@
   }
 }
 
-.select:focus.is-valid ~ .select-floating-label,
-.validate .select:focus.is-valid ~ .select-floating-label,
-.select:focus.is-valid ~ .select-filled-label,
-.validate .select:focus.is-valid ~ .select-filled-label {
+.select:focus:valid ~ .select-floating-label,
+.validate .select:focus:valid ~ .select-floating-label,
+.select:focus:valid ~ .select-filled-label,
+.validate .select:focus:valid ~ .select-filled-label {
   @apply text-success;
 }
 
-.select:focus.is-invalid ~ .select-floating-label,
-.validate .select:focus.is-invalid ~ .select-floating-label,
-.select:focus.is-invalid ~ .select-filled-label,
-.validate .select:focus.is-invalid ~ .select-filled-label {
+.select:focus:invalid ~ .select-floating-label,
+.validate .select:focus:invalid ~ .select-floating-label,
+.select:focus:invalid ~ .select-filled-label,
+.validate .select:focus:invalid ~ .select-filled-label {
   @apply text-error;
 }
 

--- a/src/components/styled/select.css
+++ b/src/components/styled/select.css
@@ -146,16 +146,16 @@
 }
 
 .select:focus.is-valid ~ .select-floating-label,
-.validate .select:focus:is-valid ~ .select-floating-label,
+.validate .select:focus.is-valid ~ .select-floating-label,
 .select:focus.is-valid ~ .select-filled-label,
-.validate .select:focus:is-valid ~ .select-filled-label {
+.validate .select:focus.is-valid ~ .select-filled-label {
   @apply text-success;
 }
 
 .select:focus.is-invalid ~ .select-floating-label,
-.validate .select:focus:is-invalid ~ .select-floating-label,
+.validate .select:focus.is-invalid ~ .select-floating-label,
 .select:focus.is-invalid ~ .select-filled-label,
-.validate .select:focus:is-invalid ~ .select-filled-label {
+.validate .select:focus.is-invalid ~ .select-filled-label {
   @apply text-error;
 }
 

--- a/src/components/styled/textarea.css
+++ b/src/components/styled/textarea.css
@@ -127,16 +127,16 @@ textarea {
 }
 
 .textarea:focus.is-valid ~ .textarea-floating-label,
-.validate .textarea:focus:is-valid ~ .textarea-floating-label,
+.validate .textarea:focus.is-valid ~ .textarea-floating-label,
 .textarea:focus.is-valid ~ .textarea-filled-label,
-.validate .textarea:focus:is-valid ~ .textarea-filled-label {
+.validate .textarea:focus.is-valid ~ .textarea-filled-label {
   @apply text-success;
 }
 
 .textarea:focus.is-invalid ~ .textarea-floating-label,
-.validate .textarea:focus:is-invalid ~ .textarea-floating-label,
+.validate .textarea:focus.is-invalid ~ .textarea-floating-label,
 .textarea:focus.is-invalid ~ .textarea-filled-label,
-.validate .textarea:focus:is-invalid ~ .textarea-filled-label {
+.validate .textarea:focus.is-invalid ~ .textarea-filled-label {
   @apply text-error;
 }
 

--- a/src/components/styled/textarea.css
+++ b/src/components/styled/textarea.css
@@ -127,16 +127,16 @@ textarea {
 }
 
 .textarea:focus.is-valid ~ .textarea-floating-label,
-.validate .textarea:focus.is-valid ~ .textarea-floating-label,
+.validate .textarea:focus:valid ~ .textarea-floating-label,
 .textarea:focus.is-valid ~ .textarea-filled-label,
-.validate .textarea:focus.is-valid ~ .textarea-filled-label {
+.validate .textarea:focus:valid ~ .textarea-filled-label {
   @apply text-success;
 }
 
 .textarea:focus.is-invalid ~ .textarea-floating-label,
-.validate .textarea:focus.is-invalid ~ .textarea-floating-label,
+.validate .textarea:focus:invalid ~ .textarea-floating-label,
 .textarea:focus.is-invalid ~ .textarea-filled-label,
-.validate .textarea:focus.is-invalid ~ .textarea-filled-label {
+.validate .textarea:focus:invalid ~ .textarea-filled-label {
   @apply text-error;
 }
 


### PR DESCRIPTION
If you use newest version of the flyonui with Next.js there is an error on page loading:
```
Parsing css source code failed
  3220 | }
  3221 | .select:focus.is-valid ~ .select-floating-label,
> 3222 | .validate .select:focus:is-valid ~ .select-floating-label,
       |                          ^
  3223 | .select:focus.is-valid ~ .select-filled-label,
  3224 | .validate .select:focus:is-valid ~ .select-filled-label {
  3225 |   --tw-text-opacity: 1;

'is-valid' is not recognized as a valid pseudo-class. Did you mean '::is-valid' (pseudo-element) or is this a typo? at [project]/src/app/globals.css:3221:25
```

this fixes it