### PR TITLE
fix(textarea): css to allow placeholder to have padding and label to be position correctly when using both trailing and leading icons

### DIFF
--- a/src/components/textarea.css
+++ b/src/components/textarea.css
@@ -43,6 +43,9 @@
     &:first-child {
       @apply py-2 ps-4;
     }
+      &:nth-child(2) {
+        @apply py-2;
+      }
     &:last-child {
       @apply py-2 pe-4;
     }
@@ -56,10 +59,15 @@
     @apply py-2 ps-4;
   }
 
+  :where(.textarea-floating:nth-child(2)) > textarea {
+    @apply py-2;
+  }
+
   :where(.textarea-floating:last-child) > textarea {
     @apply py-2 pe-4;
   }
 
+  :where(.textarea-floating:nth-child(2)) .textarea-floating-label,
   :where(.textarea-floating:last-child) .textarea-floating-label {
     @apply ms-0;
   }

--- a/src/components/textarea.css
+++ b/src/components/textarea.css
@@ -43,9 +43,9 @@
     &:first-child {
       @apply py-2 ps-4;
     }
-      &:nth-child(2) {
-        @apply py-2;
-      }
+    &:nth-child(2) {
+      @apply py-2;
+    }
     &:last-child {
       @apply py-2 pe-4;
     }


### PR DESCRIPTION
The following code
```html
<div class="textarea max-w-sm"><span class="icon-[tabler--message] text-base-content/80 mt-2 mx-4 size-5 shrink-0"></span>

<textarea class="grow resize-none" placeholder="Hello!!!"></textarea>
<span class="icon-[tabler--message] text-base-content/80 mt-2 mx-4 size-5 shrink-0"></span></div>


<div class="textarea max-w-sm"><span class="icon-[tabler--message] text-base-content/80 mt-2 mx-4 size-5 shrink-0"></span><div class="textarea-floating grow">
    
    <textarea class="resize-none" placeholder="Hello!!!" id="textareaFloatingMedium"></textarea>
<label class="textarea-floating-label" for="textareaFloatingMedium">Your bio</label></div><span class="icon-[tabler--message] text-base-content/80 mt-2 mx-4 size-5 shrink-0"></span></div>
```
is not having the right paddings giving the following elements
![image](https://github.com/user-attachments/assets/c36e142b-aa86-406a-9e36-f1a8c38ba389)

I adjusted the paddings according to the same elements when having only one icon. The final output is
![image](https://github.com/user-attachments/assets/d85563ea-2f56-4e31-9143-a1410ef56f13)
