### PR TITLE
fix: #86 Keep selected value when building options of HSSelect

### DIFF
--- a/src/js/plugins/select/index.ts
+++ b/src/js/plugins/select/index.ts
@@ -800,13 +800,14 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
         options.rest[key] = el[key]
       })
 
-      this.buildOriginalOption(title, `${value}`, id, false, false, options as ISingleOptionOptions & IApiFieldMap)
+      const isSelected = (typeof this.value === 'string' && this.value === `${value}`) || (Array.isArray(this.value) && this.value.includes(`${value}`));
+      this.buildOriginalOption(title, `${value}`, id, false, isSelected, options as ISingleOptionOptions & IApiFieldMap)
 
       this.buildOptionFromRemoteData(
         title,
         `${value}`,
         false,
-        false,
+        isSelected,
         `${i}`,
         id,
         options as ISingleOptionOptions & IApiFieldMap


### PR DESCRIPTION
Fix issue #86.

When calling functions to build the options of an `HSSelect` component, first test if the component has a value set.
Then pass the correct `selected` boolean parameter value to these build functions.