### PR TITLE
Make plugin's destroy() resilient to DOM changes

### DIFF
--- a/src/js/plugins/carousel/index.ts
+++ b/src/js/plugins/carousel/index.ts
@@ -915,8 +915,8 @@ class HSCarousel extends HSBasePlugin<ICarouselOptions> implements ICarousel {
     }
 
     // Remove elements
-    this.inner.querySelector('.snap-before').remove()
-    this.inner.querySelector('.snap-after').remove()
+    this.inner.querySelector('.snap-before')?.remove()
+    this.inner.querySelector('.snap-after')?.remove()
 
     this.dotsItems = null
 

--- a/src/js/plugins/scrollspy/index.ts
+++ b/src/js/plugins/scrollspy/index.ts
@@ -186,7 +186,7 @@ class HSScrollspy extends HSBasePlugin<IScrollspyOptions> implements IScrollspy 
   public destroy() {
     // Remove classes
     const activeLink = this.el.querySelector('[href].active')
-    activeLink.classList.remove('active')
+    activeLink?.classList.remove('active')
 
     // Remove listeners
     this.scrollable.removeEventListener('scroll', this.onScrollableScrollListener)

--- a/src/js/plugins/select/index.ts
+++ b/src/js/plugins/select/index.ts
@@ -1308,7 +1308,7 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
     this.el.classList.add('hidden')
     this.el.style.display = ''
     parent.prepend(this.el)
-    parent.querySelector('.advance-select').remove()
+    parent.querySelector('.advance-select')?.remove()
     this.wrapper = null
 
     window.$hsSelectCollection = window.$hsSelectCollection.filter(({ element }) => element.el !== this.el)

--- a/src/js/plugins/toggle-password/index.ts
+++ b/src/js/plugins/toggle-password/index.ts
@@ -125,7 +125,7 @@ class HSTogglePassword extends HSBasePlugin<ITogglePasswordOptions> implements I
   public destroy() {
     // Remove classes
     if (this.isMultiple) {
-      this.el.closest('[data-toggle-password-group]').classList.remove('active')
+      this.el.closest('[data-toggle-password-group]')?.classList.remove('active')
     } else {
       this.el.classList.remove('active')
     }


### PR DESCRIPTION
If DOM was patched, elements may be removed and some destroy() function calls will fail. This PR fixes this by checking that the requested children aren't null before operating on them.