### PR TITLE
#128 fix: Fix issue with stacked advance select tag fields

### DIFF
--- a/src/components/advanceSelect.css
+++ b/src/components/advanceSelect.css
@@ -48,7 +48,6 @@
     --tw-shadow-color: color-mix(in oklab, var(--input-color) 30%, #0000);
     outline: 1px solid var(--input-color);
     border-color: var(--input-color);
-    isolation: isolate;
   }
   &:focus-visible {
     outline: unset;


### PR DESCRIPTION
Fixes #128 

Remove `isolation: isolate;` from `.advance-select-tag` class, which cause an overlapping issue in the stacking context in contentious with other select tag fields in the same form. 