### PR TITLE
fix(stat): add fixed font-size for stat-title

### DIFF
--- a/src/components/stat.css
+++ b/src/components/stat.css
@@ -21,7 +21,7 @@
   @apply col-start-2 row-span-3 row-start-1 place-self-center justify-self-end;
 }
 .stat-title {
-  @apply text-base-content/80 col-start-1 whitespace-nowrap;
+  @apply text-base-content/80 col-start-1 text-base whitespace-nowrap;
 }
 .stat-value {
   @apply text-base-content col-start-1 text-3xl font-semibold whitespace-nowrap;


### PR DESCRIPTION
Although I don't have access to the figma files I suppose the font size of the stat title must be fixed and I encountered that, if we add a custom font size to the parent element also the stat title size changes:

```
<div class="stats text-3xl">
  <div class="stat">
    <div class="stat-title">Total Emails Sent</div>
    <div class="stat-value">76,250</div>
    <div class="stat-desc">18% more than last month</div>
  </div>
</div>
```

<img width="662" height="348" alt="image" src="https://github.com/user-attachments/assets/58d8d6c0-8669-490a-8019-6fbd5cf3ffc6" />
